### PR TITLE
Fix TXT record according to RFC and dns_parser

### DIFF
--- a/examples/simple_advertisement.rs
+++ b/examples/simple_advertisement.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         .set_ttl(Duration::from_secs(1000)))
                                     .add_answer(ResourceRecord::IN(
                                             "marin._myservice._tcp.local",
-                                            RData::txt("foobar")))
+                                            RData::txt(&["foobar"])))
                                     .header_mut()
                                     .set_id(rand::random())
                                     .set_query(false);

--- a/src/dns/packet.rs
+++ b/src/dns/packet.rs
@@ -74,6 +74,7 @@ impl<'a> PacketBuilder<'a> {
 mod test {
     use super::*;
     use dns_parser::Class;
+    use mdns::RecordKind;
     use std::time::Duration;
     use std::net::Ipv4Addr;
     use super::super::rdata::a::Record as A;
@@ -92,7 +93,7 @@ mod test {
             name: "_service._tcp.local",
             ttl: Duration::from_secs(4500),
             class: Class::IN,
-            data: crate::dns::RData::TXT(Txt("foobar")),
+            data: crate::dns::RData::TXT(Txt(&["foo=bar", "baz=qux", "foobar"])),
         };
 
         let mut packet = PacketBuilder::new();
@@ -105,5 +106,11 @@ mod test {
         let parsed = Packet::parse(&packet).unwrap();
         let packet = mdns::Response::from_packet(&parsed);
         println!("{:#?}", packet);
+
+        if let RecordKind::TXT(ref txt) = packet.answers.get(1).unwrap().kind {
+            assert_eq!(txt, &["foo=bar", "baz=qux", "foobar"]);
+        } else {
+            panic!("Expected TXT record");
+        }
     }
 }

--- a/src/dns/rdata/txt.rs
+++ b/src/dns/rdata/txt.rs
@@ -1,8 +1,7 @@
-use super::super::append_u16;
 use super::super::traits::AppendBytes;
 
 #[derive(Debug)]
-pub struct Record<'a>(pub &'a str);
+pub struct Record<'a>(pub &'a[&'a str]);
 
 impl<'a> Record<'a> {
     pub const TYPE: usize =  16;
@@ -10,13 +9,9 @@ impl<'a> Record<'a> {
 
 impl AppendBytes for Record<'_> {
     fn append_bytes(&self, out: &mut Vec<u8>) {
-        let idx = out.len();
-        append_u16(out, 0);
-        for c in self.0.bytes() {
-            out.push(c);
+        for s in self.0 {
+            out.push(s.len() as u8);
+            out.extend_from_slice(s.as_bytes());
         }
-        let len = out[idx..].len() - 2;
-        out[idx] = ((len >> 8) & 0xff) as u8;
-        out[idx + 1] = (len & 0xff) as u8;
     }
 }

--- a/src/dns/resource_record.rs
+++ b/src/dns/resource_record.rs
@@ -89,7 +89,7 @@ impl<'a> RData<'a> {
         Self::SRV(Srv { port, weight, priority, target})
     }
 
-    pub fn txt(txt: &'a str) -> Self {
+    pub fn txt(txt: &'a [ &'a str]) -> Self {
         Self::TXT(Txt (txt))
     }
 }


### PR DESCRIPTION
Fix TXT record, added multiple strings in a record again and make it match what the RFC and dns_parser expects, added test to make sure that's the case.

More importantly, note that the size of each string in the txt record is not written as a u16 but as a u8 (max size of 255 bytes per string), as you can see from dns_parser code: https://github.com/tailhook/dns-parser/blob/191266705b30feabe9fbf9289b4cb4da0ea2be31/src/rdata/txt.rs#L49

Also the RFC: https://tools.ietf.org/html/rfc6763#section-6.1