### PR TITLE
Add support for IPv6 query response

### DIFF
--- a/src/dns/packet.rs
+++ b/src/dns/packet.rs
@@ -76,8 +76,9 @@ mod test {
     use dns_parser::Class;
     use mdns::RecordKind;
     use std::time::Duration;
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
     use super::super::rdata::a::Record as A;
+    use super::super::rdata::aaaa::Record as AAAA;
     use super::super::rdata::txt::Record as Txt;
     use dns_parser::Packet;
 
@@ -87,7 +88,7 @@ mod test {
             name: "_service._tcp.local",
             ttl: Duration::from_secs(4500),
             class: Class::IN,
-            data: crate::dns::RData::A(A(Ipv4Addr::new(0, 0, 0, 0))),
+            data: crate::dns::RData::A(A(Ipv4Addr::new(7, 123, 234, 1))),
         };
         let answer2 = ResourceRecord {
             name: "_service._tcp.local",
@@ -95,13 +96,20 @@ mod test {
             class: Class::IN,
             data: crate::dns::RData::TXT(Txt(&["foo=bar", "baz=qux", "foobar"])),
         };
+        let answer3 = ResourceRecord {
+            name: "_service._tcp.local",
+            ttl: Duration::from_secs(4500),
+            class: Class::IN,
+            data: crate::dns::RData::AAAA(AAAA(Ipv6Addr::new(0xabcd, 0x4391, 0xd53a, 0x98dd, 0x7a4f, 0x0000, 0xffff, 0x0123))),
+        };
 
         let mut packet = PacketBuilder::new();
 
         packet.header_mut().set_id(12);
         packet
             .add_answer(answer1)
-            .add_answer(answer2);
+            .add_answer(answer2)
+            .add_answer(answer3);
         let packet = packet.build();
         let parsed = Packet::parse(&packet).unwrap();
         let packet = mdns::Response::from_packet(&parsed);

--- a/src/dns/rdata/aaaa.rs
+++ b/src/dns/rdata/aaaa.rs
@@ -1,0 +1,17 @@
+use super::super::traits::AppendBytes;
+use std::net::Ipv6Addr;
+
+#[derive(Debug)]
+pub struct Record(pub Ipv6Addr);
+
+impl Record {
+    pub const TYPE: usize = 28;
+}
+
+impl AppendBytes for Record {
+    fn append_bytes(&self, out: &mut Vec<u8>) {
+        for b in u128::to_be_bytes(self.0.into()).iter() {
+            out.push(*b);
+        }
+    }
+}

--- a/src/dns/rdata/mod.rs
+++ b/src/dns/rdata/mod.rs
@@ -1,4 +1,5 @@
 pub mod a;
+pub mod aaaa;
 pub mod ptr;
 pub mod srv;
 pub mod txt;

--- a/src/dns/resource_record.rs
+++ b/src/dns/resource_record.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 use super::rdata::a::Record as A;
+use super::rdata::aaaa::Record as AAAA;
 use super::rdata::ptr::Record as Ptr;
 use super::rdata::srv::Record as Srv;
 use super::rdata::txt::Record as Txt;
@@ -71,6 +72,7 @@ impl<'a> AppendBytes for ResourceRecord<'a> {
 #[derive(Debug)]
 pub enum RData<'a> {
     A(A),
+    AAAA(AAAA),
     PTR(Ptr<'a>),
     SRV(Srv<'a>),
     TXT(Txt<'a>),
@@ -83,6 +85,10 @@ impl<'a> RData<'a> {
 
     pub fn a(addr: Ipv4Addr) -> Self {
         Self::A(A(addr))
+    }
+
+    pub fn aaaa(addr: Ipv6Addr) -> Self {
+        Self::AAAA(AAAA(addr))
     }
 
     pub fn srv(port: u16, priority: u16, weight: u16, target: &'a str) -> Self {
@@ -98,6 +104,7 @@ impl AppendBytes for RData<'_> {
     fn append_bytes(&self, out: &mut Vec<u8>) {
         match self {
             RData::A(data) => data.append_bytes(out),
+            RData::AAAA(data) => data.append_bytes(out),
             RData::PTR(data) => data.append_bytes(out),
             RData::SRV(data) => data.append_bytes(out),
             RData::TXT(data) => data.append_bytes(out),
@@ -109,6 +116,7 @@ impl RData<'_> {
     fn code(&self) -> u16 {
         match self {
             RData::A(_) => A::TYPE as u16,
+            RData::AAAA(_) => AAAA::TYPE as u16,
             RData::PTR(_) => Ptr::TYPE as u16,
             RData::SRV(_) => Srv::TYPE as u16,
             RData::TXT(_) => Txt::TYPE as u16,


### PR DESCRIPTION
Also added a simple test to check that the value is parsed correctly, running with `cargo test -- --nocapture`

Unrelated, but I've considered changing the simple_advertisement example to submit the local machine's IP addresses instead of a random hardcoded one, as I expect most users of the library to want to advertise services on their own machine. 

The standard library doesn't have a way to obtain the network adapters IP address and there are a lot of crates out there that do it but they are either abandoned or only work for linux or windows, which can be confusing.

I'm using this one myself, and it works on both Linux and Windows and it's actively maintained: https://crates.io/crates/if-addrs. 
I can submit a PR if you're interested.